### PR TITLE
chore(renovate): ignore inter-module Maven dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -64,6 +64,16 @@
             "enabled": false
         },
         {
+            "description": "Ignore inter-module Maven dependencies",
+            "matchDatasources": [
+                "maven"
+            ],
+            "matchPackageNames": [
+                "guru.springframework.sfg-pet-clinic:*"
+            ],
+            "enabled": false
+        },
+        {
             "matchCategories": [
                 "docker"
             ],


### PR DESCRIPTION
Multi-Module-Projekt: `sfg-pet-clinic-web` hat eine Dependency auf das interne Modul `guru.springframework.sfg-pet-clinic:sfg-pet-clinic-data` (Version `${project.version}`).

Renovate versucht diese Inter-Modul-Dependency extern aufzulösen (Lookup-Fehler im Dependency Dashboard). Neue packageRule `Ignore inter-module Maven dependencies` (`matchPackageNames: ["guru.springframework.sfg-pet-clinic:*"]` → `enabled: false`) ignoriert alle internen Module.